### PR TITLE
Followed the compilation warning advice and replaced the usage of erl…

### DIFF
--- a/src/uid.erl
+++ b/src/uid.erl
@@ -359,4 +359,4 @@ seq() ->
 %%
 %% host unique identifier
 hid(Node) ->
-   <<(erlang:phash(Node, 1 bsl 32)):32>>.
+   <<(erlang:phash2(Node, 1 bsl 32)):32>>.


### PR DESCRIPTION
Hi, I updated the uid:hid/1 function to clear out the compilation warnings on OTP 24+

* https://www.erlang.org/doc/man/erlang.html#phash-2
* https://www.erlang.org/doc/general_info/deprecations.html#otp-24

```
===> Compiling uid
_build/default/lib/uid/src/uid.erl:362:7: Warning: erlang:phash/2 is deprecated; use erlang:phash2/2 instead
```